### PR TITLE
Report errors to logging module through AddSerilogWebError instead of intrusive HttpContext.AddError

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 image: Visual Studio 2017
 build_script:
-- ps: ./Build.ps1 -majorMinor "3.0" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- ps: ./Build.ps1 -majorMinor "4.0" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:
 - path: SerilogWeb.*.nupkg
 deploy:

--- a/src/SerilogWeb.Classic.WebApi/Classic/WebApi/WebApiExceptionLogger.cs
+++ b/src/SerilogWeb.Classic.WebApi/Classic/WebApi/WebApiExceptionLogger.cs
@@ -1,5 +1,6 @@
 ﻿using System.Web;
 using System.Web.Http.ExceptionHandling;
+using SerilogWeb.Classic.Extensions;
 
 namespace SerilogWeb.Classic.WebApi
 {
@@ -7,7 +8,10 @@ namespace SerilogWeb.Classic.WebApi
     {
         public override void Log(ExceptionLoggerContext context)
         {
-            HttpContext.Current.AddError(context.Exception);
+            if (context.Exception != null)
+            {
+                HttpContext.Current.AddSerilogWebError(context.Exception);
+            }
         }
     }
 }

--- a/src/SerilogWeb.Classic.WebApi/SerilogWeb.Classic.WebApi.csproj
+++ b/src/SerilogWeb.Classic.WebApi/SerilogWeb.Classic.WebApi.csproj
@@ -42,12 +42,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Serilog.2.7.1\lib\net45\Serilog.dll</HintPath>
     </Reference>
-    <Reference Include="SerilogWeb.Classic, Version=4.2.0.0, Culture=neutral, PublicKeyToken=9462ddd55fbc0e7f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SerilogWeb.Classic.4.2.42\lib\net45\SerilogWeb.Classic.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SerilogWeb.Classic, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9462ddd55fbc0e7f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SerilogWeb.Classic.5.0.48\lib\net45\SerilogWeb.Classic.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/SerilogWeb.Classic.WebApi/SerilogWeb.Classic.WebApi.nuspec
+++ b/src/SerilogWeb.Classic.WebApi/SerilogWeb.Classic.WebApi.nuspec
@@ -7,7 +7,7 @@
     <description>Adds WebAPI exception logging to SerilogWeb.Classic</description>
     <language>en-US</language>
     <projectUrl>https://github.com/serilog-web/classic-webapi</projectUrl>
-    <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <license type="expression">Apache-2.0</license>
     <iconUrl>https://serilog-web.github.io/pages/images/serilog-web.png</iconUrl>
     <tags>serilog logging aspnet webapi</tags>
   </metadata>

--- a/src/SerilogWeb.Classic.WebApi/packages.config
+++ b/src/SerilogWeb.Classic.WebApi/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
-  <package id="Serilog" version="2.6.0" targetFramework="net45" />
-  <package id="SerilogWeb.Classic" version="4.2.42" targetFramework="net45" />
+  <package id="Serilog" version="2.7.1" targetFramework="net45" />
+  <package id="SerilogWeb.Classic" version="5.0.48" targetFramework="net45" />
 </packages>

--- a/test/SerilogWeb.Classic.WebApi.Test/SerilogWeb.Classic.WebApi.Test.csproj
+++ b/test/SerilogWeb.Classic.WebApi.Test/SerilogWeb.Classic.WebApi.Test.csproj
@@ -55,8 +55,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.6.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Serilog.2.7.1\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Settings.AppSettings, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Settings.AppSettings.2.1.2\lib\net45\Serilog.Settings.AppSettings.dll</HintPath>
@@ -68,9 +67,8 @@
     <Reference Include="Serilog.Sinks.Trace, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.Trace.2.1.0\lib\net45\Serilog.Sinks.Trace.dll</HintPath>
     </Reference>
-    <Reference Include="SerilogWeb.Classic, Version=4.2.0.0, Culture=neutral, PublicKeyToken=9462ddd55fbc0e7f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SerilogWeb.Classic.4.2.42\lib\net45\SerilogWeb.Classic.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SerilogWeb.Classic, Version=5.0.0.0, Culture=neutral, PublicKeyToken=9462ddd55fbc0e7f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SerilogWeb.Classic.5.0.48\lib\net45\SerilogWeb.Classic.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/test/SerilogWeb.Classic.WebApi.Test/packages.config
+++ b/test/SerilogWeb.Classic.WebApi.Test/packages.config
@@ -36,10 +36,10 @@
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
-  <package id="Serilog" version="2.6.0" targetFramework="net452" />
+  <package id="Serilog" version="2.7.1" targetFramework="net452" />
   <package id="Serilog.Settings.AppSettings" version="2.1.2" targetFramework="net452" />
   <package id="Serilog.Sinks.Observable" version="2.0.1" targetFramework="net452" />
   <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net452" />
-  <package id="SerilogWeb.Classic" version="4.2.42" targetFramework="net452" />
+  <package id="SerilogWeb.Classic" version="5.0.48" targetFramework="net452" />
   <package id="WebGrease" version="1.5.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Use `HttpContext.AddSerilogWebError` (introduced in *SerilogWeb.Classic* v5.0) instead of `HttpContext.AddError` to store the exception to be logged. 

This should solve #16 and #3 , by getting rid of all the strange effects that touching HttpContext errors can cause, specially with IIS and custom errors.